### PR TITLE
feat: Implementar react-router-dom para enrutamiento avanzado

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,21 +12,22 @@
         "html5-qrcode": "^2.3.8",
         "mercadopago": "^2.8.0",
         "papaparse": "^5.5.3",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.7.0",
         "recharts": "^3.1.0",
         "transbank-sdk": "^6.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@tailwindcss/postcss": "^4.1.11",
-        "@types/react": "^19.1.8",
-        "@types/react-dom": "^19.1.6",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.6.0",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.30.1",
-        "eslint-plugin-react-hooks": "^5.2.0",
-        "eslint-plugin-react-refresh": "^0.4.20",
+        "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-react-refresh": "^0.4.7",
         "globals": "^16.3.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
@@ -2491,24 +2492,32 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "devOptional": true,
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
-      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/use-sync-external-store": {
@@ -2853,6 +2862,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2872,7 +2890,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -3268,16 +3286,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -3876,7 +3894,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4236,6 +4253,18 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4614,32 +4643,29 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -4672,6 +4698,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/recharts": {
@@ -4802,10 +4866,13 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4816,6 +4883,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "papaparse": "^5.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^7.7.0",
     "recharts": "^3.1.0",
     "transbank-sdk": "^6.1.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,42 +1,22 @@
-import React, { useState, useEffect, lazy, Suspense } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
     collection,
     onSnapshot,
     doc,
     addDoc,
     updateDoc,
-    deleteDoc,
-    writeBatch
+    deleteDoc
 } from 'firebase/firestore';
 import { db, appId } from './firebase/config.jsx';
 import { useAuth } from './hooks/useAuth.js';
-// Asumimos que este servicio existe para la lógica de Transbank
-// import { confirmWebpayTransaction } from './services/transbankService.js';
-
-// --- Componentes y Vistas ---
-// Componentes principales cargados al inicio
 import Navbar from './components/Navbar.jsx';
 import ModalMessage from './components/ModalMessage.jsx';
 import AuthScreen from './views/AuthScreen.jsx';
 import DashboardSkeleton from './components/DashboardSkeleton.jsx';
-import ProductListSkeleton from './components/ProductListSkeleton.jsx';
-import Dashboard from './views/Dashboard.jsx';
-import ProductList from './views/ProductList.jsx';
-import ProductForm from './views/ProductForm.jsx';
-import StockAdjustment from './views/StockAdjustment.jsx';
-import MovementHistory from './views/MovementHistory.jsx';
-import Reports from './views/Reports.jsx';
-import Settings from './views/Settings.jsx';
-import Suppliers from './views/Suppliers.jsx';
-import ExpirationReport from './views/ExpirationReport.jsx';
-
-// Carga perezosa (Lazy Loading) para el Punto de Venta
-// Esto mejora el rendimiento inicial y requiere <Suspense> para funcionar.
-const PointOfSale = lazy(() => import('./views/PointOfSale.jsx'));
-
+import AppRoutes from './routes/index.jsx'; // Importar el componente de rutas
 
 // --- Custom Hook para manejar la lógica del inventario ---
-// Este hook centraliza la carga de datos de Firestore.
 const useInventory = (userId) => {
     const [products, setProducts] = useState([]);
     const [movements, setMovements] = useState([]);
@@ -78,7 +58,6 @@ const useInventory = (userId) => {
         const unsubMovements = onSnapshot(collection(db, paths.movements),
             (snap) => {
                 const movementList = snap.docs.map(d => ({ id: d.id, ...d.data() }));
-                // Ordenar por fecha descendente
                 movementList.sort((a, b) => new Date(b.date) - new Date(a.date));
                 setMovements(movementList);
             },
@@ -98,53 +77,33 @@ const useInventory = (userId) => {
             }
         );
 
-        // Función de limpieza para desuscribirse de los listeners de Firestore
         return () => {
             unsubProducts();
             unsubMovements();
             unsubSuppliers();
         };
-    }, [userId]); // Se ejecuta de nuevo si el userId cambia
+    }, [userId]);
 
     return { products, movements, categories, suppliers, loading, error };
 };
 
-
 // --- Componente Principal de la Aplicación ---
 const App = () => {
-    // Hooks de autenticación e inventario
     const { user, loading: authLoading, error: authError, registerWithEmail, loginWithEmail, logout } = useAuth();
     const { products, movements, categories, suppliers, loading: dataLoading, error: dataError } = useInventory(user?.uid);
+    const navigate = useNavigate();
 
-    // Estado para la navegación y la UI
-    const [view, setView] = useState('dashboard');
     const [selectedProduct, setSelectedProduct] = useState(null);
     const [modal, setModal] = useState(null);
     const [settings, setSettings] = useState(null);
     const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
 
-    // Efecto para manejar el tema (claro/oscuro)
     useEffect(() => {
         const root = window.document.documentElement;
         root.classList.toggle('dark', theme === 'dark');
         localStorage.setItem('theme', theme);
     }, [theme]);
 
-    // Efecto para sincronizar la vista con la URL (hash)
-    useEffect(() => {
-        const handleHashChange = () => {
-            const hash = window.location.hash.replace('#', '');
-            const validViews = ['dashboard', 'pos', 'products', 'add-product', 'edit-product', 'suppliers', 'reports', 'settings', 'adjust-stock', 'movements', 'expiration-report'];
-            setView(validViews.includes(hash) ? hash : 'dashboard');
-        };
-        
-        window.addEventListener('hashchange', handleHashChange);
-        handleHashChange(); // Sincronizar al cargar la página
-
-        return () => window.removeEventListener('hashchange', handleHashChange);
-    }, []);
-
-    // Efecto para cargar la configuración del usuario desde Firestore
     useEffect(() => {
         if (!user) return;
 
@@ -153,7 +112,6 @@ const App = () => {
             if (docSnap.exists()) {
                 setSettings(docSnap.data());
             } else {
-                // Configuración por defecto si no existe
                 setSettings({ inventoryMethod: 'cpp', posProvider: 'none' });
             }
         });
@@ -161,19 +119,16 @@ const App = () => {
         return () => unsubscribe();
     }, [user]);
 
-    // --- Funciones Auxiliares (pasadas como props) ---
-    const navigateTo = (newView) => { window.location.hash = newView; };
     const toggleTheme = () => setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
     const showModal = (message, type = "info", onConfirm = null) => setModal({ message, type, onConfirm });
     const closeModal = () => setModal(null);
 
-    // --- Funciones CRUD (Create, Read, Update, Delete) ---
     const handleAddProduct = async (newProduct) => {
         if (!user) return;
         try {
             await addDoc(collection(db, `artifacts/${appId}/users/${user.uid}/products`), newProduct);
             showModal("Producto añadido con éxito.", "info");
-            navigateTo("products");
+            navigate("/products");
         } catch (err) {
             showModal("Error al añadir el producto.", "error");
         }
@@ -185,7 +140,7 @@ const App = () => {
             const { id, ...dataToUpdate } = updatedProduct;
             await updateDoc(doc(db, `artifacts/${appId}/users/${user.uid}/products`, id), dataToUpdate);
             showModal("Producto actualizado con éxito.", "info");
-            navigateTo("products");
+            navigate("/products");
             setSelectedProduct(null);
         } catch (err) {
             showModal("Error al actualizar el producto.", "error");
@@ -197,7 +152,7 @@ const App = () => {
         showModal("¿Estás seguro de que quieres eliminar este producto?", "error", async () => {
             try {
                 await deleteDoc(doc(db, `artifacts/${appId}/users/${user.uid}/products`, productId));
-                closeModal(); // Cierra el modal de confirmación
+                closeModal();
                 showModal("Producto eliminado.", "info");
             } catch (err) {
                 closeModal();
@@ -206,7 +161,6 @@ const App = () => {
         });
     };
     
-    // --- Renderizado de la Aplicación ---
     if (authLoading) {
         return <div className="min-h-screen flex items-center justify-center dark:bg-gray-900 dark:text-white">Cargando autenticación...</div>;
     }
@@ -215,80 +169,49 @@ const App = () => {
         return <AuthScreen onLogin={loginWithEmail} onRegister={registerWithEmail} error={authError} />;
     }
 
-    const renderContent = () => {
-        if (dataLoading || settings === null) {
-            if (view === 'dashboard') {
-                return <DashboardSkeleton />;
-            }
-            if (view === 'products') {
-                return <ProductListSkeleton />;
-            }
-            return <div className="text-center p-10 dark:text-gray-300">Cargando datos...</div>;
-        }
+    if (dataLoading || settings === null) {
+        return <DashboardSkeleton />;
+    }
 
-        if (dataError) {
-            return <div className="text-center p-10 text-red-500">{dataError}</div>;
-        }
+    if (dataError) {
+        return <div className="text-center p-10 text-red-500">{dataError}</div>;
+    }
 
-        // Objeto de props comunes para pasar a todos los componentes de las vistas
-        // Esto evita dependencias circulares, ya que todo fluye hacia abajo.
-        const commonProps = {
-            products,
-            userId: user.uid,
-            db,
-            appId,
-            setView: navigateTo,
-            showModal,
-            closeModal,
-            onBack: () => navigateTo('dashboard'),
-            settings
-        };
-
-        switch (view) {
-            case 'dashboard':
-                return <Dashboard {...commonProps} movements={movements} />;
-            case 'pos':
-                // Aquí se usa Suspense como fallback mientras se carga el componente PointOfSale
-                return (
-                    <Suspense fallback={<div className="text-center p-10 dark:text-gray-300">Cargando Punto de Venta...</div>}>
-                        <PointOfSale {...commonProps} />
-                    </Suspense>
-                );
-            case 'products':
-                return <ProductList {...commonProps} categories={categories} setSelectedProduct={setSelectedProduct} handleDeleteProduct={handleDeleteProduct} />;
-            case 'add-product':
-                return <ProductForm onSave={handleAddProduct} onCancel={() => navigateTo('products')} suppliers={suppliers} settings={settings} />;
-            case 'edit-product':
-                return <ProductForm productToEdit={selectedProduct} onSave={handleUpdateProduct} onCancel={() => navigateTo('products')} suppliers={suppliers} settings={settings} />;
-            case 'adjust-stock':
-                return <StockAdjustment {...commonProps} />;
-            case 'movements':
-                return <MovementHistory movements={movements} onBack={() => navigateTo('dashboard')} />;
-            case 'reports':
-                return <Reports products={products} movements={movements} onBack={() => navigateTo('dashboard')} />;
-            case 'expiration-report':
-                return <ExpirationReport products={products} onBack={() => navigateTo('dashboard')} />;
-            case 'settings':
-                return <Settings {...commonProps} />;
-            case 'suppliers':
-                return <Suppliers {...commonProps} suppliers={suppliers} />;
-            default:
-                return <Dashboard {...commonProps} movements={movements} />;
-        }
+    const routeProps = {
+        products,
+        movements,
+        categories,
+        suppliers,
+        userId: user.uid,
+        db,
+        appId,
+        showModal,
+        closeModal,
+        settings,
+        setSelectedProduct,
+        handleDeleteProduct,
+        handleAddProduct,
+        handleUpdateProduct,
     };
 
     return (
         <div className="min-h-screen bg-gray-100 dark:bg-gray-900 font-sans flex flex-col">
-            <Navbar setView={navigateTo} currentView={view} onLogout={logout} theme={theme} toggleTheme={toggleTheme} />
+            <Navbar onLogout={logout} theme={theme} toggleTheme={toggleTheme} />
             <main className="flex-grow container mx-auto px-4 py-8">
                 <div className="text-right text-xs text-gray-500 dark:text-gray-400 mb-4">
                     Usuario: <span className="font-semibold">{user.email}</span>
                 </div>
-                {renderContent()}
+                <AppRoutes {...routeProps} />
             </main>
             {modal && <ModalMessage {...modal} onClose={closeModal} onConfirm={modal.onConfirm} />}
         </div>
     );
+};
+
+// --- Componente contenedor para usar useNavigate ---
+const AppWrapper = () => {
+  const navigate = useNavigate();
+  return <App navigate={navigate} />;
 };
 
 export default App;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,84 +1,52 @@
 import React from "react";
+import { Link, useLocation } from "react-router-dom";
 
-// La Navbar ahora recibe la función onLogout
-const Navbar = ({ setView, currentView, onLogout }) => {
-  console.log("Renderizando Navbar. Vista actual:", currentView);
-  const getButtonClass = (viewName) => {
+const Navbar = ({ onLogout }) => {
+  const location = useLocation();
+
+  const getLinkClass = (path) => {
     const baseClass =
       "px-3 py-2 rounded-lg text-white font-medium text-base border border-transparent transition duration-200";
-    if (currentView === viewName) {
-      return `${baseClass} bg-blue-500`; // Estilo para el botón activo
+    if (location.pathname === path) {
+      return `${baseClass} bg-blue-500`; // Estilo para el enlace activo
     }
-    return `${baseClass} hover:bg-blue-600`; // Estilo para botones inactivos
+    return `${baseClass} hover:bg-blue-600`; // Estilo para enlaces inactivos
   };
 
   return (
     <nav className="bg-gradient-to-r from-blue-700 to-blue-900 p-3 shadow-lg sticky top-0 z-30">
       <div className="container mx-auto flex flex-wrap justify-between items-center">
-        <div className="text-white text-xl font-extrabold tracking-wide">
+        <Link to="/dashboard" className="text-white text-xl font-extrabold tracking-wide">
           🐝 Apialan Inventario
-        </div>
+        </Link>
         <div className="flex flex-wrap items-center space-x-1">
-          <button
-            onClick={() => setView("dashboard")}
-            className={getButtonClass("dashboard")}
-          >
+          <Link to="/dashboard" className={getLinkClass("/dashboard")}>
             Dashboard
-          </button>
-          <button
-            onClick={() => setView("pos")}
-            className={`${getButtonClass(
-              "pos"
-            )} bg-green-500 hover:bg-green-600`}
-          >
+          </Link>
+          <Link to="/pos" className={`${getLinkClass("/pos")} bg-green-500 hover:bg-green-600`}>
             Punto de Venta
-          </button>
-          <button
-            onClick={() => setView("products")}
-            className={getButtonClass("products")}
-          >
+          </Link>
+          <Link to="/products" className={getLinkClass("/products")}>
             Productos
-          </button>
-          <button
-            onClick={() => setView("suppliers")}
-            className={getButtonClass("suppliers")}
-          >
+          </Link>
+          <Link to="/suppliers" className={getLinkClass("/suppliers")}>
             Proveedores
-          </button>
-
-          {/* --- BOTONES RESTAURADOS --- */}
-          <button
-            onClick={() => setView("adjust-stock")}
-            className={getButtonClass("adjust-stock")}
-          >
+          </Link>
+          <Link to="/stock-adjustment" className={getLinkClass("/stock-adjustment")}>
             Ajustar
-          </button>
-          <button
-            onClick={() => setView("movements")}
-            className={getButtonClass("movements")}
-          >
+          </Link>
+          <Link to="/movements" className={getLinkClass("/movements")}>
             Movimientos
-          </button>
-
-          <button
-            onClick={() => setView("reports")}
-            className={getButtonClass("reports")}
-          >
+          </Link>
+          <Link to="/reports" className={getLinkClass("/reports")}>
             Reportes
-          </button>
-          <button
-            onClick={() => setView("expiration-report")}
-            className={getButtonClass("expiration-report")}
-          >
+          </Link>
+          <Link to="/reports/expiration" className={getLinkClass("/reports/expiration")}>
             Control de Caducidad
-          </button>
-          <button
-            onClick={() => setView("settings")}
-            className={getButtonClass("settings")}
-          >
+          </Link>
+          <Link to="/settings" className={getLinkClass("/settings")}>
             Configuración
-          </button>
-
+          </Link>
           <button
             onClick={onLogout}
             className="px-3 py-2 rounded-lg text-white font-medium text-base bg-red-500 hover:bg-red-600 transition"

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App.jsx";
 // BORRA O COMENTA LA SIGUIENTE LÍNEA:
 // import './index.css'
 
+const AppWrapper = () => {
+  return (
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
+};
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <AppWrapper />
   </React.StrictMode>
 );

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,0 +1,47 @@
+import React, { lazy, Suspense } from 'react';
+import { Routes, Route } from 'react-router-dom';
+
+import Dashboard from '../views/Dashboard';
+import ProductList from '../views/ProductList';
+import ProductForm from '../views/ProductForm';
+import StockAdjustment from '../views/StockAdjustment';
+import MovementHistory from '../views/MovementHistory';
+import Reports from '../views/Reports';
+import Settings from '../views/Settings';
+import Suppliers from '../views/Suppliers';
+import ExpirationReport from '../views/ExpirationReport';
+import ProductsLayout from '../views/ProductsLayout';
+
+const PointOfSale = lazy(() => import('../views/PointOfSale'));
+
+const AppRoutes = (props) => {
+  // Objeto de props comunes para pasar a todos los componentes de las vistas
+  const commonProps = {
+    ...props,
+    setView: () => {}, // Esta función será reemplazada por la navegación de react-router-dom
+    onBack: () => window.history.back(),
+  };
+
+  return (
+    <Suspense fallback={<div className="text-center p-10 dark:text-gray-300">Cargando...</div>}>
+      <Routes>
+        <Route path="/" element={<Dashboard {...commonProps} movements={props.movements} />} />
+        <Route path="/dashboard" element={<Dashboard {...commonProps} movements={props.movements} />} />
+        <Route path="/pos" element={<PointOfSale {...commonProps} />} />
+        <Route path="/products" element={<ProductsLayout />}>
+          <Route index element={<ProductList {...commonProps} categories={props.categories} setSelectedProduct={props.setSelectedProduct} handleDeleteProduct={props.handleDeleteProduct} />} />
+          <Route path="add" element={<ProductForm onSave={props.handleAddProduct} onCancel={() => window.history.back()} suppliers={props.suppliers} settings={props.settings} />} />
+          <Route path="edit/:productId" element={<ProductForm products={props.products} onSave={props.handleUpdateProduct} onCancel={() => window.history.back()} suppliers={props.suppliers} settings={props.settings} />} />
+        </Route>
+        <Route path="/stock-adjustment" element={<StockAdjustment {...commonProps} />} />
+        <Route path="/movements" element={<MovementHistory movements={props.movements} onBack={() => window.history.back()} />} />
+        <Route path="/reports" element={<Reports products={props.products} movements={props.moveodes} onBack={() => window.history.back()} />} />
+        <Route path="/reports/expiration" element={<ExpirationReport products={props.products} onBack={() => window.history.back()} />} />
+        <Route path="/settings" element={<Settings {...commonProps} />} />
+        <Route path="/suppliers" element={<Suppliers {...commonProps} suppliers={props.suppliers} />} />
+      </Routes>
+    </Suspense>
+  );
+};
+
+export default AppRoutes;

--- a/src/views/ProductForm.jsx
+++ b/src/views/ProductForm.jsx
@@ -1,15 +1,18 @@
 import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import BarcodeScanner from "../components/BarcodeScanner.jsx";
 import { useBarcodeReader } from "../hooks/useBarcodeReader.js";
 
-// El formulario ahora recibe la lista de 'suppliers' como una prop
 const ProductForm = ({
-  productToEdit,
+  products = [],
   onSave,
   onCancel,
   showModal,
   suppliers = [],
 }) => {
+  const { productId } = useParams();
+  const productToEdit = productId ? products.find(p => p.id === productId) : null;
+
   const initialState = {
     name: "",
     description: "",
@@ -33,8 +36,6 @@ const ProductForm = ({
   const [formData, setFormData] = useState(initialState);
   const [isScannerOpen, setIsScannerOpen] = useState(false);
 
-  // --- Lógica de Escáner Físico ---
-  // Cuando se escanea un código, se establece en el campo 'barcode' del formulario.
   useBarcodeReader((barcode) => {
     setFormData((prev) => ({ ...prev, barcode }));
   });
@@ -50,7 +51,6 @@ const ProductForm = ({
   const handleScanSuccess = (decodedText) => {
     setIsScannerOpen(false);
     setFormData((prev) => ({ ...prev, barcode: decodedText }));
-    showModal(`Código de barras escaneado: ${decodedText}`, "info");
   };
 
   const handleChange = (e) => {
@@ -68,10 +68,10 @@ const ProductForm = ({
       return;
     }
 
-    // --- LÓGICA PARA CPP ---
-    // Si estamos creando un producto nuevo, calculamos su valor de stock inicial.
     let dataToSave = { ...formData };
-    if (!productToEdit) {
+    if (productToEdit) {
+      dataToSave.id = productToEdit.id;
+    } else {
       const valorTotalDelStock =
         (parseFloat(formData.purchasePrice) || 0) *
         (parseInt(formData.stock, 10) || 0);

--- a/src/views/ProductList.jsx
+++ b/src/views/ProductList.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import { Link } from "react-router-dom";
 import { doc, updateDoc, writeBatch, collection } from "firebase/firestore";
 import { unparse } from "papaparse";
 
@@ -253,12 +254,12 @@ const ProductList = ({
             >
               Exportar CSV
             </button>
-            <button
-              onClick={() => setView("add-product")}
+            <Link
+              to="add"
               className="px-4 py-2 bg-blue-600 text-white rounded-md"
             >
               + Añadir
-            </button>
+            </Link>
           </div>
         </div>
 
@@ -330,15 +331,13 @@ const ProductList = ({
                         Ver Lotes
                       </button>
                     )}
-                    <button
-                      onClick={() => {
-                        setSelectedProduct(product);
-                        setView("edit-product");
-                      }}
+                    <Link
+                      to={`edit/${product.id}`}
+                      onClick={() => setSelectedProduct(product)}
                       className="text-blue-600 hover:underline mr-4"
                     >
                       Editar
-                    </button>
+                    </Link>
                     <button
                       onClick={() => handleDeleteProduct(product.id)}
                       className="text-red-600 hover:underline"

--- a/src/views/ProductsLayout.jsx
+++ b/src/views/ProductsLayout.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const ProductsLayout = () => {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+};
+
+export default ProductsLayout;


### PR DESCRIPTION
He refactorizado la aplicación para usar `react-router-dom` en lugar de la lógica de enrutamiento basada en hash. Esto incluye:

- Instalación de `react-router-dom`.
- Configuración de `BrowserRouter`.
- Creación de un componente de rutas dedicado.
- Reemplazo de la navegación por componentes `<Link>`.
- Implementación de rutas anidadas para la sección de productos.
- Uso de `useParams` para capturar parámetros de la URL.