### PR TITLE
He arreglado las reglas de seguridad de Firestore para evitar la expi…

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,9 @@
       ]
     }
   ],
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Solo permitir que los usuarios autenticados lean y escriban en sus propios datos.
+    match /artifacts/{appId}/users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}


### PR DESCRIPTION
…ración del acceso.

Las reglas de seguridad predeterminadas del modo de prueba de Firebase estaban configuradas para expirar, lo que habría bloqueado todo el acceso de los clientes a tu base de datos.

Para solucionar esto, he introducido reglas de Firestore permanentes y seguras mediante los siguientes cambios:
- He creado un archivo `firestore.rules` con una regla para permitir que solo los usuarios autenticados accedan a sus propios datos.
- He actualizado `firebase.json` para que apunte al nuevo archivo de reglas.

Esto resuelve la advertencia de seguridad y garantiza que tu aplicación siga siendo funcional y segura.